### PR TITLE
Fixes for mobile devices and save last values in localStorage for quick replay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/html">
 	<head>
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<style>
 			body {
 				font-family: Monospace;
@@ -11,6 +12,21 @@
 			#container {
 				height: 492px;
 				width: 876px;
+			}
+			#selector{
+				overflow-y: auto;
+				max-height: 100vh;
+				max-width: 100vw;
+			}
+			.flex{
+				display: flex;
+				flex-wrap: wrap;
+			}
+			#play{
+				display: inline-block;
+				padding: 0 2em;
+				line-height: 2;
+				margin-top: 1ex;
 			}
 		</style>
 		<script src="lib/jquery-1.8.3.min.js"></script>
@@ -108,13 +124,13 @@
 			<h3>Play online charts!</h3>
 
 
-			<div>
-				<div style="float:left;">
+			<div class="flex">
+				<div>
 					<label for="stage">Select Stage: </label><br>
 					<select id="stage" size="15" name="stage"></select><br>
 				</div>
 
-				<div style="float:left;">
+				<div>
 					<label for="online-song">Select Song: </label><br>
 					<select id="online-song" size="15" name="online-song" style="min-width: 200px;">
 					</select><br>
@@ -168,10 +184,8 @@
 				</tr>
 			</table><br>
 
-			<div>
-
-
-				<div style="float:left;">
+			<div class="flex">
+				<div>
 					<label for="noteskin">Select Noteskin: </label><br>
 					<select id="noteskin" name="speed" size="10">
 

--- a/js/utils/chartsDiscover.js
+++ b/js/utils/chartsDiscover.js
@@ -41,6 +41,7 @@ function discoverLevels( sscPath ) {
 }
 
 $("#level").live('change', function() {
+    localStorage.setItem("last_level", $(this).val());
     change_level($(this).val())
 });
 
@@ -121,7 +122,17 @@ $( "#play" ).click(function() {
 
 });
 
+$( "#noteskin" ).live("change", function(){
+  localStorage.setItem("last_noteskin", $(this).val());
+});
 
+$( "#speed" ).live("change", function(){
+  localStorage.setItem("last_speed", $(this).val());
+});
+
+$( "#offset" ).live("change", function(){
+  localStorage.setItem("last_offset", $(this).val());
+});
 
 function readSongList() {
 
@@ -150,12 +161,27 @@ function readSongList() {
 
         }
 
+        /* Set default selection for dynamic values: Stage, Song and Level */
+
+        let default_stage = localStorage.getItem("last_stage") !== null ? parseInt(localStorage.getItem("last_stage")) : 14 ;
+        change_stage(default_stage) ;
+        $( "#stage" ).val(default_stage) ;
+
+        let default_song = localStorage.getItem("last_song") !== null ? parseInt(localStorage.getItem("last_song")) : 0 ;
+        $( "#online-song" ).val(default_song) ;
+        $( "#online-song" ).trigger("change") ;
+
+        let default_level = localStorage.getItem("last_level") !== null ? parseInt(localStorage.getItem("last_level")) : 0 ;
+        change_level(default_level) ;
+        $( "#level" ).val(default_level) ;
+
 
     });
 }
 
 $("#stage").live('change', function() {
 
+    localStorage.setItem("last_stage", $(this).val());
     change_stage($(this).val()) ;
 
 
@@ -191,6 +217,8 @@ function change_stage(i) {
 
 $("#online-song").live('change', function() {
     // alert('The option with value ' + $(this).val());
+
+    localStorage.setItem("last_song", $(this).val());
 
     clear('level')
 
@@ -228,7 +256,17 @@ $("#online-song").live('change', function() {
 
 });
 
-
+/* Load dynamic values and set thise defaults */
 
 readSongList() ;
-change_stage(14) ;
+
+/* Set default selection for static values: Noteskin, Speed and Offset */
+
+let default_noteskin = localStorage.getItem("last_noteskin") !== null ? localStorage.getItem("last_noteskin") : "EXCEED2-OLD" ;
+$( "#noteskin" ).val(default_noteskin) ;
+
+let default_speed = localStorage.getItem("last_speed") !== null ? parseInt(localStorage.getItem("last_speed")) : 4 ;
+$( "#speed" ).val(default_speed) ;
+
+let default_offset = localStorage.getItem("last_offset") !== null ? parseFloat(localStorage.getItem("last_offset")) : "0.0" ;
+$( "#offset" ).val(default_offset) ;


### PR DESCRIPTION
This PR includes two simple commits only affecting the menu UI (chartsDiscover.js).

1.  Some fixes for the menu to show better on mobile devices. Enables scrollbar in the menu if needed, sets the viewport scale, removes the "float:left" in divs and uses flexbox instead. Original layout and workflow has been respected.

2. Static values Noteskin, Speed and Offset (values are set directly in the HTML code) and dynamic values Stage, Song and Level (loaded from external resources and changed depending on the selections) are saved in localStorage and re-applied on page reload. This also affects how defaults are handled, so if you want to change the default selection, you should change them here too. This change allows quicker replay for training purposes.